### PR TITLE
feat: background mode on podcast

### DIFF
--- a/ios/Chat/Info.plist
+++ b/ios/Chat/Info.plist
@@ -87,6 +87,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
To allow background audio playback on iOS, was needed to activate the ‘Audio, Airplay and Picture in Picture’ background mode in Xcode.